### PR TITLE
Version2

### DIFF
--- a/Refresh.cls
+++ b/Refresh.cls
@@ -2,7 +2,7 @@ public class Refresh {
     public static void accountRatingHot(list<Account> newlst){
         for(Account acc:newlst ){
             IF(acc.annualrevenue==null && acc.Rating.equals('Hot'))
-                acc.annualrevenue=1002200;
+                acc.annualrevenue=200;
         }
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Adjusted the assignment logic for `annualrevenue` in the account rating process, changing the default value for 'Hot' accounts from `1002200` to `200`. This change aims to improve accuracy in revenue calculations related to account ratings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->